### PR TITLE
added acc lockout, firmwareversion,hostuptime checks

### DIFF
--- a/config_assurance_results.json
+++ b/config_assurance_results.json
@@ -1,6 +1,6 @@
 {
-    "execution_timestamp": "2025-08-07T09:23:17Z",
-    "failed_checks": "2",
+    "execution_timestamp": "2025-08-11T11:16:47Z",
+    "failed_checks": "5",
     "hosts": [
         {
             "checks": {
@@ -26,6 +26,18 @@
                     "actual_config": "AD joined: no, Domain: ",
                     "compliant": true,
                     "expected_config": "Host should not be joined to any domain",
+                    "status": "PASS"
+                },
+                "Host OS/Firmware Mapping Compliance": {
+                    "actual_config": "ESXi version: 8.0.2; Firmware: 6.00 (approved: ['6.30', '6.40'])",
+                    "compliant": false,
+                    "expected_config": "Firmware as mapped for ESXi version",
+                    "status": "FAIL"
+                },
+                "Host Uptime Compliance": {
+                    "actual_config": "Host uptime is 13.64 days (threshold: 90 days)",
+                    "compliant": true,
+                    "expected_config": "Uptime \u2264 90 days",
                     "status": "PASS"
                 },
                 "Lockdown Mode Compliance": {
@@ -60,14 +72,14 @@
                     "compliance_result": "pass",
                     "compliant": true,
                     "hostname": "esxi01.kubelab.demo",
-                    "timestamp": "2025-08-07T14:53:13+0530"
+                    "timestamp": "2025-08-11T16:46:45+0530"
                 }
             },
-            "failed_checks": "0",
+            "failed_checks": "1",
             "hostname": "esxi01.kubelab.demo",
-            "overall_compliant": true,
-            "passed_checks": "9",
-            "total_checks": "9"
+            "overall_compliant": false,
+            "passed_checks": "10",
+            "total_checks": "11"
         },
         {
             "checks": {
@@ -93,6 +105,18 @@
                     "actual_config": "AD joined: no, Domain: ",
                     "compliant": true,
                     "expected_config": "Host should not be joined to any domain",
+                    "status": "PASS"
+                },
+                "Host OS/Firmware Mapping Compliance": {
+                    "actual_config": "ESXi version: 8.0.2; Firmware: 6.00 (approved: ['6.30', '6.40'])",
+                    "compliant": false,
+                    "expected_config": "Firmware as mapped for ESXi version",
+                    "status": "FAIL"
+                },
+                "Host Uptime Compliance": {
+                    "actual_config": "Host uptime is 11.51 days (threshold: 90 days)",
+                    "compliant": true,
+                    "expected_config": "Uptime \u2264 90 days",
                     "status": "PASS"
                 },
                 "Lockdown Mode Compliance": {
@@ -127,14 +151,14 @@
                     "compliance_result": "pass",
                     "compliant": true,
                     "hostname": "esxi02.kubelab.demo",
-                    "timestamp": "2025-08-07T14:53:13+0530"
+                    "timestamp": "2025-08-11T16:46:45+0530"
                 }
             },
-            "failed_checks": "1",
+            "failed_checks": "2",
             "hostname": "esxi02.kubelab.demo",
             "overall_compliant": false,
-            "passed_checks": "8",
-            "total_checks": "9"
+            "passed_checks": "9",
+            "total_checks": "11"
         },
         {
             "checks": {
@@ -160,6 +184,18 @@
                     "actual_config": "AD joined: no, Domain: ",
                     "compliant": true,
                     "expected_config": "Host should not be joined to any domain",
+                    "status": "PASS"
+                },
+                "Host OS/Firmware Mapping Compliance": {
+                    "actual_config": "ESXi version: 8.0.2; Firmware: 6.00 (approved: ['6.30', '6.40'])",
+                    "compliant": false,
+                    "expected_config": "Firmware as mapped for ESXi version",
+                    "status": "FAIL"
+                },
+                "Host Uptime Compliance": {
+                    "actual_config": "Host uptime is 11.51 days (threshold: 90 days)",
+                    "compliant": true,
+                    "expected_config": "Uptime \u2264 90 days",
                     "status": "PASS"
                 },
                 "Lockdown Mode Compliance": {
@@ -194,18 +230,18 @@
                     "compliance_result": "pass",
                     "compliant": true,
                     "hostname": "esxi03.kubelab.demo",
-                    "timestamp": "2025-08-07T14:53:13+0530"
+                    "timestamp": "2025-08-11T16:46:45+0530"
                 }
             },
-            "failed_checks": "1",
+            "failed_checks": "2",
             "hostname": "esxi03.kubelab.demo",
             "overall_compliant": false,
-            "passed_checks": "8",
-            "total_checks": "9"
+            "passed_checks": "9",
+            "total_checks": "11"
         }
     ],
     "overall_compliance": false,
-    "passed_checks": "25",
-    "total_checks": "27",
+    "passed_checks": "28",
+    "total_checks": "33",
     "total_hosts": "3"
 }

--- a/roles/vmware-host-config-assurance/defaults/main.yml
+++ b/roles/vmware-host-config-assurance/defaults/main.yml
@@ -16,3 +16,21 @@ ntp_servers:
 
 # Time offset threshold in seconds
 time_offset_threshold: 5  # Maximum acceptable time drift in seconds
+
+# Account lockout failure threshold (e.g. max failed login attempts allowed)
+account_lockout_threshold: 5 # Maximum allowed failed login attempts before account lockout
+
+# host uptime check
+patch_cycle_threshold_days: 90 # Maximum allowed uptime in days before patching is required
+
+# approved_firmware_versions:
+#  - "6.00"
+#  - "2.0.0.1"
+#  - "3.1.4.1"
+# Add all approved firmware versions here
+
+esxi_firmware_approval_map:
+  "7.0": ["6.00", "6.01"]
+  "7.1": ["6.20"]
+  "8.0": ["6.30", "6.40"]
+

--- a/roles/vmware-host-config-assurance/tasks/checks/account_lockout_check.yml
+++ b/roles/vmware-host-config-assurance/tasks/checks/account_lockout_check.yml
@@ -6,7 +6,7 @@
 
 - name: Fail if account lockout info not found in collected facts
   fail:
-    msg: "Account lockout info 'Security.AccountLockFailures' not found in collected_host_facts.config.option.Ensure its collected by vmware_host_facts."
+    msg: "Account lockout info 'Security.AccountLockFailures' not found in collected_host_facts.config.option. Ensure it is collected."
   when: not account_lockout_in_facts
   tags: account_lockout_check
 
@@ -18,18 +18,18 @@
           | selectattr('key', 'equalto', 'Security.AccountLockFailures') 
           | map(attribute='value') 
           | list 
-          | first ) | default('not found')
+          | first) | default('not found')
       }}
   when: account_lockout_in_facts
   tags: account_lockout_check
 
-- name: Assert account lockout failure threshold is 5 or fewer
+- name: Assert account lockout failure threshold compliance
   assert:
     that:
       - account_lockout_value != 'not found'
-      - account_lockout_value | int <= 5
-    fail_msg: "Account lockout failure threshold is set above 5, current value is {{ account_lockout_value }}."
-    success_msg: "Account lockout failure threshold is correctly set to 5 or less."
+      - account_lockout_value | int <= account_lockout_threshold
+    fail_msg: "Account lockout failure threshold is set above {{ account_lockout_threshold }}, current value is {{ account_lockout_value }}."
+    success_msg: "Account lockout failure threshold is correctly set to {{ account_lockout_threshold }} or less."
   when: account_lockout_in_facts
   tags: account_lockout_check
 
@@ -39,9 +39,9 @@
     check_name: "Account Lockout Failure Threshold"
     task_result:
       changed: false
-      failed: "{{ account_lockout_value | int > 5 }}"
+      failed: "{{ account_lockout_value | int > account_lockout_threshold }}"
       msg: "Account lockout failure threshold: {{ account_lockout_value }}"
-    expected_config: "5 or fewer"
+    expected_config: "{{ account_lockout_threshold }} or fewer"
   tags: account_lockout_check
 
 - name: Display account lockout failure threshold per host

--- a/roles/vmware-host-config-assurance/tasks/checks/firmware_version_check.yml
+++ b/roles/vmware-host-config-assurance/tasks/checks/firmware_version_check.yml
@@ -1,0 +1,64 @@
+---
+- name: Check if OS and firmware info are available in collected facts
+  set_fact:
+    os_firmware_info_in_facts: >-
+      {{
+        collected_host_facts is defined and
+        collected_host_facts.summary is defined and
+        collected_host_facts.summary.config is defined and
+        collected_host_facts.summary.config.product is defined and
+        collected_host_facts.summary.config.product.version is defined and
+        collected_host_facts.hardware is defined and
+        collected_host_facts.hardware.biosInfo is defined and
+        collected_host_facts.hardware.biosInfo.biosVersion is defined
+      }}
+  tags: host_firmware_check
+
+- name: Fail if OS or firmware info not in collected facts
+  fail:
+    msg: "OS version or firmware version missing in collected_host_facts. Ensure 'summary.config.product.version' and 'hardware.biosInfo.biosVersion' are collected."
+  when: not os_firmware_info_in_facts
+  tags: host_firmware_check
+
+- name: Get current OS and firmware versions
+  set_fact:
+    current_esxi_os_version: "{{ collected_host_facts.summary.config.product.version }}"
+    current_firmware_version: "{{ collected_host_facts.hardware.biosInfo.biosVersion }}"
+  when: os_firmware_info_in_facts
+  tags: host_firmware_check
+
+- name: Lookup approved firmware for the current OS version
+  set_fact:
+    approved_fw_for_os: "{{ esxi_firmware_approval_map.get(current_esxi_os_version.split('.')[0] ~ '.' ~ current_esxi_os_version.split('.')[1], []) }}"
+  when: os_firmware_info_in_facts
+  tags: host_firmware_check
+
+- name: Set compliance based on firmware mapping logic
+  set_fact:
+    firmware_compliant: >-
+      {{
+        (approved_fw_for_os is string and current_firmware_version == approved_fw_for_os)
+        or
+        (approved_fw_for_os is sequence and current_firmware_version in approved_fw_for_os)
+      }}
+  when: os_firmware_info_in_facts
+  tags: host_firmware_check
+
+- name: Report Host Firmware Mapping Compliance
+  include_tasks: utils/report_assurance_result.yml
+  vars:
+    check_name: "Host OS/Firmware Mapping Compliance"
+    task_result:
+      changed: false
+      failed: "{{ not firmware_compliant }}"
+      msg: >-
+        ESXi version: {{ current_esxi_os_version }}; Firmware: {{ current_firmware_version }} (approved: {{ approved_fw_for_os }})
+    expected_config: "Firmware as mapped for ESXi version"
+  when: os_firmware_info_in_facts
+  tags: host_firmware_check
+
+- name: Show mapping per host
+  debug:
+    msg: "{{ inventory_hostname }}: ESXi {{ current_esxi_os_version }} → Firmware {{ current_firmware_version }} (approved: {{ approved_fw_for_os }})"
+  when: os_firmware_info_in_facts
+  tags: host_firmware_check

--- a/roles/vmware-host-config-assurance/tasks/checks/firmware_version_check.yml.orig
+++ b/roles/vmware-host-config-assurance/tasks/checks/firmware_version_check.yml.orig
@@ -1,0 +1,48 @@
+---
+- name: Check if firmware info is available in collected facts
+  set_fact:
+    firmware_in_facts: >-
+      {{
+        collected_host_facts is defined and
+        collected_host_facts.hardware is defined and
+        collected_host_facts.hardware.biosInfo is defined and
+        collected_host_facts.hardware.biosInfo.biosVersion is defined
+      }}
+  tags: host_firmware_check
+
+- name: Fail if firmware info not found in collected facts
+  fail:
+    msg: "Firmware info not found in collected_host_facts. Please ensure 'hardware.biosInfo.biosVersion' is collected by vmware_host_facts module."
+  when: not firmware_in_facts
+  tags: host_firmware_check
+
+- name: Set current firmware version fact
+  set_fact:
+    current_firmware_version: "{{ collected_host_facts.hardware.biosInfo.biosVersion }}"
+  when: firmware_in_facts
+  tags: host_firmware_check
+
+- name: Check firmware compliance against approved versions
+  set_fact:
+    firmware_compliant: "{{ current_firmware_version in approved_firmware_versions }}"
+  when: firmware_in_facts
+  tags: host_firmware_check
+
+- name: Report Host Firmware Compliance
+  include_tasks: utils/report_assurance_result.yml
+  vars:
+    check_name: "Host Firmware Compliance"
+    task_result:
+      changed: false
+      failed: "{{ not firmware_compliant }}"
+      msg: >-
+        Firmware version is {{ current_firmware_version }} (approved versions: {{ approved_firmware_versions | join(', ') }})
+    expected_config: "Firmware version in approved list"
+  when: firmware_in_facts
+  tags: host_firmware_check
+
+- name: Display host firmware version per host
+  debug:
+    msg: "{{ inventory_hostname }}: Firmware version {{ current_firmware_version }}"
+  when: firmware_in_facts
+  tags: host_firmware_check

--- a/roles/vmware-host-config-assurance/tasks/checks/host_uptime_check.yml
+++ b/roles/vmware-host-config-assurance/tasks/checks/host_uptime_check.yml
@@ -1,0 +1,48 @@
+---
+- name: Check if uptime info is available in collected facts
+  set_fact:
+    uptime_in_facts: >-
+      {{
+        collected_host_facts is defined and
+        collected_host_facts.summary is defined and
+        collected_host_facts.summary.quickStats is defined and
+        collected_host_facts.summary.quickStats.uptime is defined
+      }}
+  tags: host_uptime_check
+
+- name: Fail if uptime info not found in collected facts
+  fail:
+    msg: "Host uptime info not found in collected_host_facts. Please ensure 'summary.quickStats.uptime' is collected by vmware_host_facts module."
+  when: not uptime_in_facts
+  tags: host_uptime_check
+
+- name: Calculate host uptime in days
+  set_fact:
+    host_uptime_days: "{{ (collected_host_facts.summary.quickStats.uptime | float) / 86400 }}"
+  when: uptime_in_facts
+  tags: host_uptime_check
+
+- name: Set compliance status based on uptime threshold
+  set_fact:
+    uptime_compliant: "{{ (host_uptime_days | float) <= (patch_cycle_threshold_days | float) }}"
+  when: uptime_in_facts
+  tags: host_uptime_check
+
+- name: Report Host Uptime Compliance
+  include_tasks: utils/report_assurance_result.yml
+  vars:
+    check_name: "Host Uptime Compliance"
+    task_result:
+      changed: false
+      failed: "{{ not uptime_compliant }}"
+      msg: >-
+        Host uptime is {{ (host_uptime_days | float) | round(2) }} days (threshold: {{ patch_cycle_threshold_days }} days)
+    expected_config: "Uptime ≤ {{ patch_cycle_threshold_days }} days"
+  when: uptime_in_facts
+  tags: host_uptime_check
+
+- name: Display host uptime in days for each host
+  debug:
+    msg: "{{ inventory_hostname }}: {{ (host_uptime_days | float) | round(2) }} days"
+  when: uptime_in_facts
+  tags: host_uptime_check

--- a/roles/vmware-host-config-assurance/tasks/main.yml
+++ b/roles/vmware-host-config-assurance/tasks/main.yml
@@ -25,6 +25,16 @@
 - name: Include account lockout check
   include_tasks: checks/account_lockout_check.yml
   when: inventory_hostname in groups.get('discovered_esxi_hosts', [])
+ 
+- name: Include host uptime compliance check
+  include_tasks: checks/host_uptime_check.yml
+  when: inventory_hostname in groups.get('discovered_esxi_hosts', [])
+  tags: host_uptime_check
+
+- name: Include host firmware compliance check
+  include_tasks: checks/firmware_version_check.yml
+  when: inventory_hostname in groups.get('discovered_esxi_hosts', [])
+  tags: host_firmware_check
 
 - name: Finalize host results for JSON output
   set_fact:

--- a/roles/vmware-host-config-assurance/tasks/utils/collect_host_facts.yml
+++ b/roles/vmware-host-config-assurance/tasks/utils/collect_host_facts.yml
@@ -16,6 +16,8 @@
       - summary.config
       - config.lockdownMode
       - config.authenticationManagerInfo
+      - summary.quickStats
+      - hardware.biosInfo
   register: host_facts_async
   delegate_to: localhost
   async: 300

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -1,0 +1,10 @@
+tags_reference:
+  - check_name: "Account Lockout Check"
+    tag: account_lockout_check
+    description: "Validates ESXi account lockout settings (e.g., failures, unlock time)."
+  - check_name: "Host Uptime Compliance"
+    tag: host_uptime_check
+    description: "Ensures ESXi host uptime is below patch cycle threshold."
+  - check_name: "Host Firmware Compliance"
+    tag: host_firmware_check
+    description: "Ensures firmware version matches ESXi OS version mapping."


### PR DESCRIPTION
1) There are two versions of firmware version check
a) Just checks if the server has valid firmware version
b) Compares the ESXi host OS version to corresponding approved firmware version.\

2) Account lockout was defaulted to the system default of "5"

3) hostuptime check was set to 90 as default.

